### PR TITLE
Move train loader initialisation after evaluation

### DIFF
--- a/trainECAPAModel.py
+++ b/trainECAPAModel.py
@@ -42,10 +42,6 @@ torch.multiprocessing.set_sharing_strategy('file_system')
 args = parser.parse_args()
 args = init_args(args)
 
-## Define the data loader
-trainloader = train_loader(**vars(args))
-trainLoader = torch.utils.data.DataLoader(trainloader, batch_size = args.batch_size, shuffle = True, num_workers = args.n_cpu, drop_last = True)
-
 ## Search for the exist models
 modelfiles = glob.glob('%s/model_0*.model'%args.model_save_path)
 modelfiles.sort()
@@ -58,6 +54,10 @@ if args.eval == True:
 	EER, minDCF = s.eval_network(eval_list = args.eval_list, eval_path = args.eval_path)
 	print("EER %2.2f%%, minDCF %.4f%%"%(EER, minDCF))
 	quit()
+
+## Define the data loader
+trainloader = train_loader(**vars(args))
+trainLoader = torch.utils.data.DataLoader(trainloader, batch_size = args.batch_size, shuffle = True, num_workers = args.n_cpu, drop_last = True)
 
 ## If initial_model is exist, system will train from the initial_model
 if args.initial_model != "":


### PR DESCRIPTION
If the user only wants to do evaluation, they don't need to define the train loader. Could you move train loader initialization after evaluation? Otherwise, there will be annoying errors.